### PR TITLE
Fix: episode number regex

### DIFF
--- a/netflix2trakt.py
+++ b/netflix2trakt.py
@@ -96,7 +96,7 @@ for show in netflixHistory.shows:
                         break
                 if not(found):
                     # Try finding episode number in the name
-                    tvshowregex = re.compile(r'Folge (\d{1,2})|Episode (\d{1,2})')
+                    tvshowregex = re.compile(r'Folge|Episode (\d{1,2})')
                     res = tvshowregex.search( episode.name )
                     if res is not None:
                         number = int(res.group(1))


### PR DESCRIPTION
This fixes an issue with episodes with `Episode X` in the title instead of `Folge X`. With this fix the number will always be at index 1 in the matched groups.