### PR TITLE
Sync all movies & episodes in a single Trakt API call

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -65,7 +65,6 @@ If execution fails with error _tmdbv3api.exceptions.TMDbException: ['query must 
 * Make note of your details to be used later.
 
 ## Future improvements:
-* Send multiple episodes to trakt in one call instead of making one API call per entry 
 * Check found TMDB shows/movies before sending to trakt.tv
 * Better print outputs
 * Code documentation improvement

--- a/TraktIO.py
+++ b/TraktIO.py
@@ -14,6 +14,9 @@ logging.basicConfig(level=config.LOG_LEVEL)
 
 class TraktIO(object):
     def __init__(self):
+        self._episodes = []
+        self._movies = []
+
         self.is_authenticating = Condition()
 
         self.authorization = None
@@ -35,13 +38,21 @@ class TraktIO(object):
                 self.authorization = json.load(infile)
 
     def addEpisodeToHistory(self, data):
-        with Trakt.configuration.oauth.from_response(self.authorization):
-            ret = Trakt["sync/history"].add(data)
-            return ret
+        self._episodes.append(data)
 
     def addMovie(self, data):
+        self._movies.append(data)
+
+    def getData(self):
+        data = {
+            "movies": self._movies,
+            "episodes": self._episodes
+        }
+        return data
+
+    def sync(self):
         with Trakt.configuration.oauth.from_response(self.authorization):
-            ret = Trakt["sync/history"].add(data)
+            ret = Trakt["sync/history"].add(self.getData())
             return ret
 
     def authenticate(self):

--- a/netflix2trakt.py
+++ b/netflix2trakt.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import csv
-import datetime
 import logging
 import re
 from time import sleep
@@ -216,14 +215,8 @@ for show in netflixHistory.shows:
         for episode in season.episodes:
             if episode.tmdbId is not None:
                 for watchedTime in episode.watchedAt:
-                    try:
-                        time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
-                    except ValueError:
-                        # try the date with a dot (also for backwards compatbility)
-                        watchedTime = re.sub("[^0-9]", ".", watchedTime)
-                        time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
                     episodeData = {
-                        "watched_at": time.strftime("%Y-%m-%dT%H:%M:%S.00Z"),
+                        "watched_at": watchedTime,
                         "ids": {"tmdb": episode.tmdbId}
                     }
                     traktIO.addEpisodeToHistory(episodeData)
@@ -232,15 +225,9 @@ for movie in netflixHistory.movies:
     if movie.tmdbId is not None:
         for watchedTime in movie.watchedAt:
             print("Adding movie to trakt: %s" % movie.name)
-            try:
-                time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
-            except ValueError:
-                # try the date with a dot (also for backwards compatbility)
-                watchedTime = re.sub("[^0-9]", ".", watchedTime)
-                time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
             movieData = {
                 "title": movie.name,
-                "watched_at": time.strftime("%Y-%m-%dT%H:%M:%S.00Z"),
+                "watched_at": watchedTime,
                 "ids": {"tmdb": movie.tmdbId},
             }
             traktIO.addMovie(movieData)

--- a/netflix2trakt.py
+++ b/netflix2trakt.py
@@ -205,18 +205,16 @@ for movie in netflixHistory.movies:
             print("Ignoring appeared exception while looking for movie %s" % movie.name)
             logging.info("Ignoring appeared exception while looking for movie %s" % movie.name)
 
-
 logging.info(netflixHistory.getJson())
-
 
 # Sync to trakt
 traktIO = TraktIO()
-traktIO.init()
+
 for show in netflixHistory.shows:
     for season in show.seasons:
+        print(f"Adding episodes to trakt: {len(season.episodes)} episodes from {show.name} season {season.number}")
         for episode in season.episodes:
             if episode.tmdbId is not None:
-                print("Adding epsiode to trakt:")
                 for watchedTime in episode.watchedAt:
                     try:
                         time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
@@ -224,33 +222,30 @@ for show in netflixHistory.shows:
                         # try the date with a dot (also for backwards compatbility)
                         watchedTime = re.sub("[^0-9]", ".", watchedTime)
                         time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
-                    addInfo = {
-                        "episodes": [
-                            {"watched_at": time.strftime("%Y-%m-%dT%H:%M:%S.00Z"), "ids": {"tmdb": episode.tmdbId}}
-                        ]
+                    episodeData = {
+                        "watched_at": time.strftime("%Y-%m-%dT%H:%M:%S.00Z"),
+                        "ids": {"tmdb": episode.tmdbId}
                     }
-                    print(addInfo)
-                    ret = traktIO.addEpisodeToHistory(addInfo)
-                    # print(ret) # Todo: Check if epsiode was really added by checking for ret["added"]["epsiodes"] == 1
-                    # Trakt API Rate limit: 1 POST call per second
-                    sleep(1.2)
+                    traktIO.addEpisodeToHistory(episodeData)
 
 for movie in netflixHistory.movies:
     if movie.tmdbId is not None:
         for watchedTime in movie.watchedAt:
-            print("Adding movie to trakt:")
-            watchedTime = re.sub("[^0-9]", ".", watchedTime)
-            time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
-            addInfo = {
-                "movies": [
-                    {
-                        "title": movie.name,
-                        "watched_at": time.strftime("%Y-%m-%dT%H:%M:%S.00Z"),
-                        "ids": {"tmdb": movie.tmdbId},
-                    }
-                ]
+            print("Adding movie to trakt: %s" % movie.name)
+            try:
+                time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
+            except ValueError:
+                # try the date with a dot (also for backwards compatbility)
+                watchedTime = re.sub("[^0-9]", ".", watchedTime)
+                time = datetime.datetime.strptime(watchedTime + " 20:15", config.CSV_DATETIME_FORMAT + " %H:%M")
+            movieData = {
+                "title": movie.name,
+                "watched_at": time.strftime("%Y-%m-%dT%H:%M:%S.00Z"),
+                "ids": {"tmdb": movie.tmdbId},
             }
-            print(addInfo)
-            ret = traktIO.addMovie(addInfo)
-            # print(ret) # Todo: Check if movie was really added by checking for ret["added"]["movies"] == 1
-            sleep(1.2)
+            traktIO.addMovie(movieData)
+
+traktIO.init()
+ret = traktIO.sync()
+logging.info(ret)
+print("%d episodes and %d movies added to Trakt history" % (ret["added"]["episodes"], ret["added"]["movies"]))

--- a/test_NetflixTvShows.py
+++ b/test_NetflixTvShows.py
@@ -13,7 +13,7 @@ def test_addSingleTvShow():
     assert netflixHistory.shows[0].name == "Peaky Blinders – Gangs of Birmingham"
     assert int(netflixHistory.shows[0].seasons[0].number) == 1
     assert netflixHistory.shows[0].seasons[0].name is None
-    assert netflixHistory.shows[0].seasons[0].episodes[0].watchedAt[0] == "03.10.21"
+    assert netflixHistory.shows[0].seasons[0].episodes[0].watchedAt[0] == "2021-10-03T20:15:00.00Z"
 
 
 def test_addMultipleTvShows():
@@ -41,4 +41,4 @@ def test_addMovie():
     netflixHistory = NetflixTvHistory()
     netflixHistory.addEntry("Spider-Man: Far from Home", "16.09.21")
     assert netflixHistory.getMovie("Spider-Man: Far from Home") is not None
-    assert netflixHistory.movies[0].watchedAt[0] == "16.09.21"
+    assert netflixHistory.movies[0].watchedAt[0] == "2021-09-16T20:15:00.00Z"


### PR DESCRIPTION
Roll-up all movie & episode submissions into a single call to the Trakt history API. This is dramatically faster for large CSVs.

I also noticed that the date parsing logic for movies & episodes had diverged in 94b7454, so I DRY'ed those in 2f0f0ab. I can make a separate PR for that if you want.