### PR TITLE
New: Option to search for translated episode names

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,6 +12,9 @@ TMDB_API_KEY = ""
 TMDB_LANGUAGE = "en"
 TMDB_DEBUG = False
 TMDB_SYNC_STRICT = True
+TMDB_EPISODE_LANGUAGE_SEARCH = False # more api calls, longer waiting time, 
+                                     # only useful if the tmdb language differs from en 
+                                     # and episodes cannot be found in the season overview Api calls
 
 TRAKT_API_CLIENT_ID = ""
 TRAKT_API_CLIENT_SECRET = ""


### PR DESCRIPTION
Sometimes the TMDB Api returns english (original) episode names in the season overview. By checking each epsiode for the given language the search results can be improved. However, the script will take longer
and more API calls are made. This should only be used if the tmdb language setting differs from english and some episodes cannot be found.