### PR TITLE
New: Connect to Trakt first + more checks for outdated authorization

### DIFF
--- a/netflix2trakt.py
+++ b/netflix2trakt.py
@@ -21,9 +21,15 @@ tmdb.api_key = config.TMDB_API_KEY
 tmdb.language = config.TMDB_LANGUAGE
 tmdb.debug = config.TMDB_DEBUG
 
+# Setup trakt
+# Sync to trakt
+traktIO = TraktIO(page_size=config.TRAKT_API_SYNC_PAGE_SIZE,
+                  dry_run=config.TRAKT_API_DRY_RUN)
+traktIO.init()
+
 # Load Netlix Viewing History and loop through every entry
 netflixHistory = NetflixTvHistory()
-with open(config.VIEWING_HISTORY_FILENAME, mode="r") as csvFile:
+with open(config.VIEWING_HISTORY_FILENAME, mode="r", encoding="utf-8") as csvFile:
     # Make sure the file has a header "Title, Date" (first line)
     csvReader = csv.DictReader(csvFile, fieldnames=("Title", "Date"))
     line_count = 0
@@ -222,10 +228,6 @@ for movie in netflixHistory.movies:
 
 logging.info(netflixHistory.getJson())
 
-# Sync to trakt
-traktIO = TraktIO(page_size=config.TRAKT_API_SYNC_PAGE_SIZE,
-                  dry_run=config.TRAKT_API_DRY_RUN)
-
 for show in netflixHistory.shows:
     for season in show.seasons:
         print(f"Adding episodes to trakt: {len(season.episodes)} episodes from {show.name} season {season.number}")
@@ -249,5 +251,5 @@ for movie in netflixHistory.movies:
             }
             traktIO.addMovie(movieData)
 
-traktIO.init()
+# Finally: Sync to trakt
 traktIO.sync()


### PR DESCRIPTION
For the authorization it is now checked from a previous json file if the acces codes are still valid. If not a refresh is tried.

The trakt authentication is moved at the start of the script, so it will break directly if authentication was not successful and not after grabbing all tv show data.

Also relates to #9