### PR TITLE
Move local configuration to a separate file that can be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-Netflix2TraktImportLog.log
+*.log
+config.ini
 dev/
 .vscode/
 __pycache__
 .python-version
 *.csv
 traktAuth.json
+venv

--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@ With this information the season is queried from TMDB.
 If the episode name from the Netflix Export matches the episode name from the TMDB season, the Id is filled in.
 
 Otherwise, it is checked if the episode number might be already in the title of the episode.
-As a last test, it is checked if the number of episodes in the season equals the number of watched episodes. If this is the case, 
+As a last test, it is checked if the number of episodes in the season equals the number of watched episodes. If this is the case,
 the script will estimate the episode number based on the viewing history (latest watched episode = last episode of the season.)
 
 If no match was found at all, the episode / movie is left out.
@@ -32,9 +32,11 @@ If no match was found at all, the episode / movie is left out.
 
 ## Installation
 Just clone this repo, fill in the API keys and language information in the config.py file.
-If your Netflix csv file uses a different datetime format (default: day.month.year) then change the CSV_DATETIME_FORMAT setting in the config.py file.
+If your Netflix csv file uses a different datetime format (default: day.month.year) then change the
+`viewing_history_datetime_format` setting in the [`config.ini` file](README.MD#configuration).
 Note: Use %Y for years like 2023 and %y for year entries like 23. 
-If your csv file uses a different delimiter as "," between date and entry, then change the CSV_DELIMITER option as well.
+If your csv file uses a different delimiter than `,` between date and entry, then change the
+`viewing_history_delimiter` option as well.
 
 See how to register API access below.
 
@@ -46,7 +48,8 @@ python -m pip install -r requirements.txt
 Also, of course a NetflixViewingHistory.csv export file is needed. This can be obtained directly from the netflix page.
 Compare https://help.netflix.com/node/101917 for more information.
 
-Note: There is currently no check if the data is already uploaded. This means, if you use the script more than once, make sure to delete all previously synced episodes/movies from the csv file.
+Note: There is currently no check if the data is already uploaded. This means, if you use the script more than once, make
+sure to delete all previously synced episodes/movies from the csv file.
 
 To use the script simply call 
 ```bash
@@ -58,7 +61,18 @@ For printing only the non-found shows just execute
 grep "No Tmdb ID found" Netflix2TraktImportLog.log 
 ```
 
-If execution fails with error _tmdbv3api.exceptions.TMDbException: ['query must be provided']_, set `TMDB_SYNC_STRICT` to **False**.
+If execution fails with error _tmdbv3api.exceptions.TMDbException: ['query must be provided']_, set the `strict` option of the
+`TMDB` section in [`config.ini` file](README.MD#configuration) to **False**.
+
+## Configuration
+
+To customize the import options, copy [`config_default.ini`](config_default.ini)
+to `config.ini` and make your changes there.
+
+```bash
+cp config_default.ini config.ini
+# open config.ini in the editor of your choice
+```
 
 ### Register API Access at Trakt
 * Go to "Settings" under your profile

--- a/config.py
+++ b/config.py
@@ -1,24 +1,36 @@
+import configparser
 import logging
+import sys
 
-LOG_FILENAME = "Netflix2TraktImportLog.log"
-LOG_LEVEL = logging.INFO
-VIEWING_HISTORY_FILENAME = "NetflixViewingHistory.csv"
+class Section(object):
+    LOGGING = 'Logging'
+    NETFLIX = 'Netflix'
+    TMDB = 'TMDB'
+    TRAKT = 'Trakt'
 
-# Set the datetime format of the csv file and the delimiter (default: %d.%m.%y for 05.02.21 and "," as delimiter between date and entry)
-# Use %Y-%m-%d for 2021-02-05 (Canada, ...)
-# For the format 17.05.2023 use the datetime format %d.%m.%Y (note the capital Y for 2023 instead of y for 23)
-CSV_DATETIME_FORMAT = "%d.%m.%y"
-CSV_DELIMITER = "," #delimiter between the entries (like "," between '"Push","28.02.23"')
 
-TMDB_API_KEY = ""
-TMDB_LANGUAGE = "en"
-TMDB_DEBUG = False
-TMDB_SYNC_STRICT = True
-TMDB_EPISODE_LANGUAGE_SEARCH = False # more api calls, longer waiting time, 
-                                     # only useful if the tmdb language differs from en 
-                                     # and episodes cannot be found in the season overview Api calls
+_config = configparser.ConfigParser()
+_config.read('config_defaults.ini')
 
-TRAKT_API_CLIENT_ID = ""
-TRAKT_API_CLIENT_SECRET = ""
-TRAKT_API_DRY_RUN = False
-TRAKT_API_SYNC_PAGE_SIZE = 1000
+# optional user configs go in config.ini
+# ignore them if we're running tests
+if "pytest" not in sys.modules: # pragma: no cover
+    _config.read('config.ini')
+
+LOG_FILENAME = _config.get(Section.LOGGING, 'filename')
+LOG_LEVEL = logging.getLevelName(_config.get(Section.LOGGING, 'level'))
+
+VIEWING_HISTORY_FILENAME = _config.get(Section.NETFLIX, 'viewing_history_filename')
+CSV_DATETIME_FORMAT = _config.get(Section.NETFLIX, 'viewing_history_datetime_format')
+CSV_DELIMITER = _config.get(Section.NETFLIX, 'viewing_history_delimiter')
+
+TMDB_API_KEY = _config.get(Section.TMDB, 'api_key')
+TMDB_LANGUAGE = _config.get(Section.TMDB, 'language')
+TMDB_DEBUG = _config.getboolean(Section.TMDB, 'debug')
+TMDB_SYNC_STRICT = _config.getboolean(Section.TMDB, 'strict')
+TMDB_EPISODE_LANGUAGE_SEARCH = _config.getboolean(Section.TMDB, 'episode_language_search')
+
+TRAKT_API_CLIENT_ID = _config.get(Section.TRAKT, 'id')
+TRAKT_API_CLIENT_SECRET = _config.get(Section.TRAKT, 'secret')
+TRAKT_API_DRY_RUN = _config.getboolean(Section.TRAKT, 'dry_run')
+TRAKT_API_SYNC_PAGE_SIZE = _config.getint(Section.TRAKT, 'page_size')

--- a/config_defaults.ini
+++ b/config_defaults.ini
@@ -1,0 +1,35 @@
+[Logging]
+filename = Netflix2TraktImportLog.log
+# Valid values for LEVEL: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
+level = INFO
+
+[Netflix]
+viewing_history_filename = NetflixViewingHistory.csv
+# viewing_history_datetime_format: Set the datetime format of the csv file and the delimiter
+# (default: %%d.%%m.%%y for 05.02.21 and "," as delimiter between date and entry)
+# Use %%Y-%%m-%%d for 2021-02-05 (Canada, ...)
+# For the format 17.05.2023 use the datetime format %%d.%%m.%%Y (note the capital Y for 2023 instead of y for 23)
+# % needs to be escaped using %%
+viewing_history_datetime_format = %%d.%%m.%%y
+# viewing_history_delimiter: delimiter between the entries (like "," between '"Push","28.02.23"')
+viewing_history_delimiter = ,
+
+[TMDB]
+# NOTE: DO NOT set a real API Key here. Use config.ini.
+api_key = None
+language = en
+debug = False
+strict = True
+# episode_language_search: Search translations for matching names
+# This results in more api calls, longer waiting time, and
+# is only useful if the tmdb language differs from en
+# and episodes cannot be found in the season overview API calls
+episode_language_search = False
+
+[Trakt]
+# NOTE: DO NOT set a real ID or secret here. Use config.ini.
+id = None
+secret = None
+# dry_run: Set to True to skip Trakt API calls
+dry_run = False
+page_size = 1000


### PR DESCRIPTION
Motivations:

1. Be able to run tests and commit changes without stashing modifications to `config.py`.
2. Prevent the accidental publication of API keys to :octocat:.

I kept the same interface as the existing config object to make this easier to review. We could take it a step further and use the structured object directly. e.g.:

```python
# Setup logging
logging.basicConfig(**config.Logging)

# Connect to TMDB
tmdb = TMDb()
tmdb.api_key = config.TMDB.api_key
tmdb.language = config.TMDB.language
tmdb.debug = config.TMDB.debug

# Setup Trakt
traktIO = TraktIO(**config.Trakt)
# etc...
```

If you want to create a `config.ini` from your existing `config.py` before merging these changes, you can use this script:

```python
import config
import configparser


outputFilename="config.ini"

newConfig = configparser.ConfigParser()
newConfig.optionxform=str

newConfig['Logging'] = {
    'filename': config.LOG_FILENAME,
    'level': config.LOG_LEVEL,
}

newConfig['Netflix'] = {
    'viewing_history_filename': config.VIEWING_HISTORY_FILENAME,
    'viewing_history_datetime_format': config.CSV_DATETIME_FORMAT.replace('%', '%%'),
    'viewing_history_delimiter': config.CSV_DELIMITER,
}

newConfig['TMDB'] = {
    'api_key': config.TMDB_API_KEY,
    'language': config.TMDB_LANGUAGE,
    'debug': config.TMDB_DEBUG,
    'strict': config.TMDB_SYNC_STRICT,
    'episode_language_search': config.TMDB_EPISODE_LANGUAGE_SEARCH,
}

newConfig['Trakt'] = {
    'id': config.TRAKT_API_CLIENT_ID,
    'secret': config.TRAKT_API_CLIENT_SECRET,
    'dry_run': config.TRAKT_API_DRY_RUN,
    'page_size': config.TRAKT_API_SYNC_PAGE_SIZE,
}

print(f"Writing {outputFilename}...")
with open(outputFilename, "w") as conf:
    newConfig.write(conf)

print(f"Done. Review {outputFilename} for correctness.")

```