### PR TITLE
Avoid breaking when `tmdbShow` is not initialized

### DIFF
--- a/netflix2trakt.py
+++ b/netflix2trakt.py
@@ -96,11 +96,13 @@ def getShowInformation(show, tmdb, languageSearch, traktIO):
     tmdbTv = TV()
     tmdbSeason = Season()
     tmdbEp = Episode()
+    tmdbShow = None
     try:
         if len(show.name.strip()) != 0:
             tmdbShow = tmdbTv.search(show.name)
-        if len(tmdbShow) == 0:
+        if tmdbShow is None or len(tmdbShow) == 0:
             logging.warning("Show %s not found on TMDB!" % show.name)
+            return
 
         showId = tmdbShow[0]["id"]
         details = tmdbTv.details(show_id=showId, append_to_response="")


### PR DESCRIPTION
Solves the following error:

```
Traceback (most recent call last):
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/.direnv/python-3.12.3/lib/python3.12/site-packages/tenacity/__init__.py", line 382, in __call__
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/netflix2trakt.py", line 102, in getShowInformation
    if len(tmdbShow) == 0:
           ^^^^^^^^
UnboundLocalError: cannot access local variable 'tmdbShow' where it is not associated with a value

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/netflix2trakt.py", line 350, in <module>
    main()
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/netflix2trakt.py", line 337, in main
    getShowInformation(show, tmdb, config.TMDB_EPISODE_LANGUAGE_SEARCH, traktIO)
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/.direnv/python-3.12.3/lib/python3.12/site-packages/tenacity/__init__.py", line 289, in wrapped_f
    return self(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/.direnv/python-3.12.3/lib/python3.12/site-packages/tenacity/__init__.py", line 379, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/humitos/Downloads/netflix-trak/Netflix-to-Trakt-Import/.direnv/python-3.12.3/lib/python3.12/site-packages/tenacity/__init__.py", line 326, in iter
    raise retry_exc from fut.exception()
tenacity.RetryError: RetryError[<Future at 0x76b68fc6f710 state=finished raised UnboundLocalError>]
```